### PR TITLE
Fix broken links on Getting Started section

### DIFF
--- a/_getting_started/getting-started-with-convox.md
+++ b/_getting_started/getting-started-with-convox.md
@@ -31,7 +31,7 @@ The `convox install` command will kick off the process of setting up Convox in y
 
 <div class="block-callout block-show-callout type-info">
   <h3>Security credentials</h3>
-  <p>To install Convox into your AWS account, the Convox CLI needs an <code>AWS Access Key ID</code> and <code>Secret Access Key</code>. We highly recommend following AWS best practices by <a href="/getting-started/creating-an-iam-user-and-credentials">creating a new IAM user to supply these credentials</a>. Once the install is complete you can safely <a href="/getting-started/deleting-an-iam-user">delete the user</a>.</p>
+  <p>To install Convox into your AWS account, the Convox CLI needs an <code>AWS Access Key ID</code> and <code>Secret Access Key</code>. We highly recommend following AWS best practices by <a href="/docs/creating-an-iam-user-and-credentials">creating a new IAM user to supply these credentials</a>. Once the install is complete you can safely <a href="/docs/deleting-an-iam-user">delete the user</a>.</p>
 </div>
 
 The installation process takes about 5 minutes. Go make a sandwich while you contemplate all of the AWS docs you're not reading and glue code you're not writing.
@@ -72,7 +72,7 @@ You can run `convox apps` to verify that your client is properly communicating w
     $ convox apps
     APP  STATUS
 
-Congratulations! Convox is set up and ready to deploy apps. Try [deploying](/getting-started/deploying-an-application) one of our sample applications.
+Congratulations! Convox is set up and ready to deploy apps. Try [deploying](/docs/deploying-an-application) one of our sample applications.
 
 <div class="block-callout block-show-callout type-warning">
   <h3>Cost Management</h3>
@@ -83,5 +83,5 @@ Congratulations! Convox is set up and ready to deploy apps. Try [deploying](/get
 
   <p>Each deployed app will provision an additional ELB which starts at $18/month.</p>
 
-  <p>At any time you can [uninstall Convox](/getting-started/uninstall-convox) to delete the resources and stop accruing costs.</p>
+  <p>At any time you can <a href="/docs/uninstall-convox"uninstall Convox</a> to delete the resources and stop accruing costs.</p>
 </div>


### PR DESCRIPTION
Adjusting the internal links to the new prefix and fixing a broken markdown link.