### PR TITLE
Fix service ordering

### DIFF
--- a/_services/postgresql.md
+++ b/_services/postgresql.md
@@ -7,14 +7,9 @@ sort: 10
 You can create PostgreSQL databases using the `convox services create` command. For example, to create a database called "pg1", use the following command:
 
     $ convox services create postgres pg1
-    Creating postgres (pg1)... CREATING
+    Creating pg1 (postgres)... CREATING
 
-This kicks off the provisioning of a Postgres database on the Amazon RDS service. Creation can take up to 15 minutes. To find out if the database available, use the following command:
-
-    $ convox services info pg1
-    Name    postgres
-    Status  creating
-    URL
+This kicks off the provisioning of a Postgres database on the Amazon RDS service. Creation can take up to 15 minutes. To check the status of the DB creation, use the command specified in "Database Info" below. The status will be 'creating' until the database becomes available.
 
 ### Database info
 
@@ -34,7 +29,9 @@ Add the URL to the environment of any app that needs to use the database. Make s
 To delete the database, use the `convox services delete` command:
 
     $ convox services delete pg1
-    Deleting pg1... OK
+    Deleting pg1... DELETING
+
+Deleting can take several minutes. Use `info` to check on the status if you like. The info command will return a status of 'deleting' until the service is successfully deleted.
 
 ### Using a 3rd party database
 

--- a/_services/redis.md
+++ b/_services/redis.md
@@ -7,7 +7,7 @@ sort: 20
 You can create Redis databases using the `convox services create` command. For example, to create a database called "redis1", use the following command:
 
     $ convox services create redis redis1
-    Creating redis1 (redis)...
+    Creating redis1 (redis)... CREATING
 
 This kicks off the provisioning of a Redis database using Amazon ElastiCache. Creation can take a few minutes. To check the status of the DB creation, use the command specified in "Database Info" below. The status will be 'creating' until the database becomes available.
 

--- a/_services/redis.md
+++ b/_services/redis.md
@@ -29,7 +29,7 @@ Add the URL to the environment of any app that needs to use the database. Make s
 To delete the database, use the `convox services delete` command:
 
     $ convox services delete redis1
-    Deleting redis1... OK
+    Deleting redis1... DELETING
 
 Deleting can take several minutes. Use `info` to check on the status if you like. The info command will return a status of 'deleting' until the service is successfully deleted.
 

--- a/_services/redis.md
+++ b/_services/redis.md
@@ -6,12 +6,10 @@ sort: 20
 
 You can create Redis databases using the `convox services create` command. For example, to create a database called "redis1", use the following command:
 
-    $ convox services create redis1 redis
-    Creating service redis1 (redis)...
+    $ convox services create redis redis1
+    Creating redis1 (redis)...
 
-This kicks off the provisioning of a Redis database. Creation can take a few minutes. When the database becomes available the command will return:
-
-    Creating service redis1 (redis)... OK, redis1
+This kicks off the provisioning of a Redis database using Amazon ElastiCache. Creation can take a few minutes. To check the status of the DB creation, use the command specified in "Database Info" below. The status will be 'creating' until the database becomes available.
 
 ### Database info
 
@@ -32,6 +30,8 @@ To delete the database, use the `convox services delete` command:
 
     $ convox services delete redis1
     Deleting redis1... OK
+
+Deleting can take several minutes. Use `info` to check on the status if you like. The info command will return a status of 'deleting' until the service is successfully deleted.
 
 ### Using a 3rd party database
 


### PR DESCRIPTION
There's a transposition error in the current docs `convox services create TYPE NAME` vs `convox services create NAME TYPE`

This builds on @superlogical's patch #38 to apply the same fix to the Redis docs.