### PR TITLE
Rename system to rack for scaling command

### DIFF
--- a/_getting_started/scaling-processes.md
+++ b/_getting_started/scaling-processes.md
@@ -62,4 +62,4 @@ Your dedicated Convox Rack is a set of instances, each with a fixed amount of me
 
 The container service keeps the last configuration running until the new configuration successfully starts.
 
-To increase your Convox Rack capacity, see the `convox system scale` command or contact support@convox.com
+To increase your Convox Rack capacity, see the `convox rack scale` command or contact support@convox.com


### PR DESCRIPTION
Remnant of old cli naming scheme?
Renamed `convox system scale` to `convox rack scale`