### PR TITLE
Added --region flag in uninstall guide

### DIFF
--- a/_documentation/uninstall-convox.md
+++ b/_documentation/uninstall-convox.md
@@ -5,6 +5,10 @@ Your rack can be uninstalled using the CLI. AWS credentials are required for thi
 
     $ convox uninstall
 
+You may specify the region your cluster is installed in with the option --region (defaults to us-east-1):
+
+    $ convox uninstall --region your-cluster-region
+
 This will remove all of the AWS data and services created by Convox.
 
     Uninstalling Convox...


### PR DESCRIPTION
Was missing an explanation of the --region flag for clusters in regions other than default us-east-1 region