### PR TITLE
replace local `convox exec` with `docker ps` and `docker exec`

### DIFF
--- a/_getting_started/developing-locally.md
+++ b/_getting_started/developing-locally.md
@@ -116,6 +116,7 @@ This allows you to administer your development app via [one-off processes][12fac
     CONTAINER ID        IMAGE                   COMMAND                  CREATED             STATUS              PORTS                    NAMES
     02d9c958720f        simple-rails/web        "sh -c bin/web"          10 seconds ago      Up 10 seconds       0.0.0.0:80->3000/tcp     simple-rails-web
     089d4504630c        simple-rails/database   "/docker-entrypoint.s"   13 seconds ago      Up 13 seconds       0.0.0.0:5432->5432/tcp   simple-rails-database
+    
     $ docker exec 02d9c958720f rake db:migrate
 
 Depending on your base image's operating system, you can can also start a shell for interactive debugging:

--- a/_getting_started/developing-locally.md
+++ b/_getting_started/developing-locally.md
@@ -106,24 +106,27 @@ A `CTRL+C` on the `convox start` process stops everything and exits.
 By using Docker, Convox is able to achieve fast setup and teardown, dev/prod parity, and an intuitive developer experience behind a simple command.
 
 
-### `convox exec <process> <command>`
+### `docker ps`, `docker exec`, etc.
 
-Convox supports executing a command within the context of one of your local running processes via the `convox exec`[CLI][cli] command.
+Convox supports executing a command within the context of one of your local running processes via `docker` commands.
 
-This allows you to administer your development app via [one-off processes][12fac-oneoff] using the same commands you would pass to `convox run`. For example, you could run database migrations via:
+This allows you to administer your development app via [one-off processes][12fac-oneoff]. For example, you could run database migrations via:
 
-    $ convox exec web rake db:migrate
+    $ docker ps
+    CONTAINER ID        IMAGE                   COMMAND                  CREATED             STATUS              PORTS                    NAMES
+    02d9c958720f        simple-rails/web        "sh -c bin/web"          10 seconds ago      Up 10 seconds       0.0.0.0:80->3000/tcp     simple-rails-web
+    089d4504630c        simple-rails/database   "/docker-entrypoint.s"   13 seconds ago      Up 13 seconds       0.0.0.0:5432->5432/tcp   simple-rails-database
+    $ docker exec 02d9c958720f rake db:migrate
 
 Depending on your base image's operating system, you can can also start a shell for interactive debugging:
 
-    $ convox exec main bash
-    $ convox exec web sh
+    $ docker exec -it 02d9c958720f bash
 
 Or start an interactive session with your favorite REPL:
 
-    $ convox exec web rails console    # rails
-    $ convox exec web node             # node.js
-    $ convox exec main psql <host>     # SQL session
+    $ docker exec -it 02d9c958720f rails console    # rails
+    $ docker exec -it cdbe5d7c48c7 node             # node.js
+    $ docker exec -it 15fdd402f094 psql <host>      # SQL session
 
 Your only limit is the software in your manifest!
 


### PR DESCRIPTION
To address a question from anton on Slack. The documentation incorrectly talks about a local `convox exec` when this command now only operates on the app running in a rack.


> How does `convox exec` know when to talk to the local docker daemon and when to talk to the rack?
> I am trying to run a one off process locally, and I'm getting this error:
> ```ERROR: InvalidParameterException: Services cannot be empty.
>        status code: 400, request id: baddd3da-d514-11e5-a7bd-b73cc91c108a```
> Incidentally, I get the same error with `convox ps`. This is in an 'undeployed' app that I am trying to test locally first before deploying.
> So I assume my attempt to run `convox exec` is talking to the rack rather than locally, even though I gave it a service name rather than a pid.
> If it matters, I don't have a `docker-compose.yml`, I have separate `prod.yml` and `local.yml` files that I specify with `-f`
> However, `convox exec` doesn't take a `-f` flag.
